### PR TITLE
Update #respond_to? signature

### DIFF
--- a/lib/block_helpers.rb
+++ b/lib/block_helpers.rb
@@ -61,8 +61,8 @@ module BlockHelpers
       body
     end
     
-    def respond_to?(method)
-      super or helper.respond_to?(method)
+    def respond_to?(method, include_all = false)
+      super or helper.respond_to?(method, include_all)
     end
 
     protected


### PR DESCRIPTION
* Ruby 2.3 deprecated the older `#respond_to?` with only 1 argument;
* it needs an optional second argument with default `false`;